### PR TITLE
Set docker API version to auto to support older daemon versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
     ports: "{{ item['ports'] | default(omit) }}"
     volumes: "{{ item['volumes'] | default(omit) }}"
     ulimits: "{{ item['ulimits'] | default(omit) }}"
+    docker_api_version: auto
   when: "{{ item['run_as_service'] | default(not container_run_as_service) }}"
   with_items: "{{ docker_containers }}"
 


### PR DESCRIPTION
Recent versions of docker-py seem to default to API version 1.24, from Docker
1.12, which breaks the role with older (but not so old) daemon versions
such as 1.10.

Fix it by manually specifying the API version as 'auto' in the docker
action.
